### PR TITLE
Fix previous patch issue : when no value for theme in config file

### DIFF
--- a/libraries/lib.inc.php
+++ b/libraries/lib.inc.php
@@ -95,6 +95,8 @@
 
 	/* select the theme */
 	unset($_theme);
+	if (!isset($conf['theme']))
+		$conf['theme'] = 'default';
 
 	// 1. Check for the theme from a request var
 	if (isset($_REQUEST['theme']) && is_file("./themes/{$_REQUEST['theme']}/global.css")) {


### PR DESCRIPTION
Before previous fix, the theme "default" was always used whatever the value in config file. As it now uses the one in config file, there was an issue if no value for theme is present in config file.

Sorry for double push request.
