### PR TITLE
Quick fixed leakage of formatting tags from autocomplete into target field.

### DIFF
--- a/ajax-ac-insert.php
+++ b/ajax-ac-insert.php
@@ -50,11 +50,11 @@
 				$finfo = $res->fetchField($j++);
 				if (in_array($n, $fkeynames))
 					echo "<td><a href=\"javascript:void(0)\" class=\"fkval\" name=\"{$keyspos[$n]}\">",
-						$misc->printVal($v, $finfo->type, array('clip' => 'collapsed')),
+						$misc->printVal($v, $finfo->type, array('clip' => 'collapsed', 'autocomplete' => 'true')),
 						"</a></td>";
 				else
 					echo "<td><a href=\"javascript:void(0)\">",
-						$misc->printVal($v, $finfo->type, array('clip' => 'collapsed')),
+						$misc->printVal($v, $finfo->type, array('clip' => 'collapsed', 'autocomplete' => 'true')),
 						"</a></td>";
 			}
 			echo "</tr>\n";

--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -280,7 +280,7 @@
 				case 'xid':
 				case 'cid':
 				case 'tid':
-					$align = 'right';
+					if (!isset($params['autocomplete'])) $align = 'right';
 					$out = nl2br(htmlspecialchars($str));
 					break;
 				case 'yesno':


### PR DESCRIPTION
Added a param to printVal in Misc, named 'autocomplete', which will prohibit the alignment of numbers if set (thus keeping `<div>` tags from showing up).  Modified the `ajax-ac-insert.php` to set the `autocomplete` param to true (not needed - actually only checks if this parameter exists) when using `$misc->printVal`.

The problem was if there was a FK consisting of multiple fields, the formatting of these fields was copied along in the autocomplete (for example in a integer field as part of a mutifield FK), resulting in invalid data in the FK field (like `<div style="text-align: right; background-color: rgb(61, 128, 223); color: rgb(255, 255, 255); ">2</div>` ending up in the field instead of just `2`)

This is a very dirty hack - better would be to keep the formatting in the table returned by `ajax-ac-insert.php` as is - but make the JavaScript which is coping the data strip the formatting tags before inserting into the FK field.  I couldn't find were the code is that does this, so this is a quick hack that works for me and i wanted to share it (formatting of non-numerical types will still cause the same problems, but one can copy the code there).

Kind regards,
Jakob
