### PR TITLE
Fix broken buttons if used multiple times

### DIFF
--- a/display.php
+++ b/display.php
@@ -530,11 +530,14 @@
 					'attr'=> array (
 						'href' => array (
 							'url' => 'display.php',
-							'urlvars' => array_merge(array (
-								'action' => 'confeditrow',
-								'strings' => $_REQUEST['strings'],
-								'page' => $_REQUEST['page'],
-							), $_gets)
+							//Update the state variables for this button
+							'urlvars' => array_merge(
+								$_gets,
+								array (
+									'action' => 'confeditrow',
+									'strings' => $_REQUEST['strings'],
+									'page' => $_REQUEST['page'])
+							)
 						)
 					)
 				),
@@ -543,11 +546,14 @@
 					'attr'=> array (
 						'href' => array (
 							'url' => 'display.php',
-							'urlvars' => array_merge(array (
-								'action' => 'confdelrow',
-								'strings' => $_REQUEST['strings'],
-								'page' => $_REQUEST['page'],
-							), $_gets)
+							//Update the state variables for this button
+							'urlvars' => array_merge(
+								$_gets,
+								array (
+									'action' => 'confeditrow',
+									'strings' => $_REQUEST['strings'],
+									'page' => $_REQUEST['page'])
+							)
 						)
 					)
 				),
@@ -557,13 +563,6 @@
 				'place' => 'display-browse'
 			);
 			$plugin_manager->do_hook('actionbuttons', $actions);
-
-			foreach (array_keys($actions['actionbuttons']) as $action) {
-				$actions['actionbuttons'][$action]['attr']['href']['urlvars'] = array_merge(
-					$actions['actionbuttons'][$action]['attr']['href']['urlvars'],
-					$_gets
-				);
-			}
 
 			$edit_params = isset($actions['actionbuttons']['edit'])?
 				$actions['actionbuttons']['edit']:array();


### PR DESCRIPTION
The bug:
- User browses a table
- Clicks on any 'edit' button
- Clicks on 'Cancel' button
- Clicks on any 'edit' button
- User is unable to edit the row (no edit screen, just the browse screen)

The Cause:
The buttons include the state information in 'urlvars'. This was done via a merge of two arrays, the first with the button information and the second contains the page state variables. Merge will override values in the first array if they are also in the second array.
Also after the buttons are defined a for-loop merges the urlvars for a second time.
