### PR TITLE
Enables querying over the inspected table

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -276,6 +276,7 @@ class Postgres extends ADODB_base {
 			case 'text':
 			case 'text[]':
 			case 'xml':
+			case 'json':
 			case 'xml[]':
 				$n = substr_count($value, "\n");
 				$n = $n < 5 ? 5 : $n;

--- a/display.php
+++ b/display.php
@@ -525,6 +525,11 @@
 		if ($save_history && is_object($rs) && ($type == 'QUERY')) //{
 			$misc->saveScriptHistory($_REQUEST['query']);
 
+		echo '<form method="POST" action="'.$_SERVER['REQUEST_URI'].'"><textarea width="90%" name="query" rows="6" cols="120" resizable="true">';
+		$query = isset($_REQUEST['query'])? $_REQUEST['query'] : "select * from {$_REQUEST['schema']}.{$_REQUEST['table']};";
+		echo $query;
+		echo '</textarea><br><input type="submit"/></form>';
+
 		if (is_object($rs) && $rs->recordCount() > 0) {
 			// Show page navigation
 			$misc->printPages($_REQUEST['page'], $max_pages, $_gets);
@@ -825,6 +830,12 @@
 		else if ($_REQUEST['subject'] == 'view') {
 			$misc->printHeader(
 				$lang['strviews'].': '.$_REQUEST[$_REQUEST['subject']],
+				$scripts
+			);
+		}
+		else if ($_REQUEST['subject'] == 'column') {
+			$misc->printHeader(
+				$lang['strcolumn'].': '.$_REQUEST[$_REQUEST['subject']],
 				$scripts
 			);
 		}


### PR DESCRIPTION
This pull requests allows the user to run queries over the inspected tables without the popup. It adds a textarea and suggest a query based on the REQUEST parameters.

![enables_direct_selection](https://cloud.githubusercontent.com/assets/238439/4462813/4324d58c-48c6-11e4-9d2d-0549af36c702.png)

If you filter the results, you still have the action buttons

![you_still_have_action_buttons](https://cloud.githubusercontent.com/assets/238439/4462823/64e306d0-48c6-11e4-828c-237cebfe2308.png)

Finally: I also added a conf to edit json fields with a textarea instead of text input 

![json_textarea](https://cloud.githubusercontent.com/assets/238439/4462839/830f659a-48c6-11e4-8d4a-5b8db0b077e7.png)

