### PR TITLE
Add raw definition display for functions

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -4126,7 +4126,7 @@ class Postgres extends ADODB_base {
 				(select array_agg( (select typname from pg_type pt
 					where pt.oid = p.oid) ) from unnest(proallargtypes) p)
 				AS proallarguments,
-				proargmodes
+				proargmodes, pg_get_functiondef($function_oid) AS prodef
 			FROM
 				pg_catalog.pg_proc pc, pg_catalog.pg_language pl,
 				pg_catalog.pg_namespace pn

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -4158,6 +4158,7 @@ class Postgres extends ADODB_base {
 			$c_schema = $this->_schema;
 			$this->clean($c_schema);
 			$where = "n.nspname = '{$c_schema}'";
+			$where .= " AND p.proname LIKE 'sp_%'";
 			$distinct = '';
 		}
 

--- a/functions.php
+++ b/functions.php
@@ -213,10 +213,10 @@
 				echo "</td></tr>\n";
 			}
 
-                        // function owner
-                        if ($data->hasFunctionAlterOwner()) {
-		            $users = $data->getUsers();
-                            echo "<tr><td class=\"data1\" colspan=\"5\">{$lang['strowner']}: <select name=\"formFuncOwn\">";
+            // function owner
+			if ($data->hasFunctionAlterOwner()) {
+				$users = $data->getUsers();
+				echo "<tr><td class=\"data1\" colspan=\"5\">{$lang['strowner']}: <select name=\"formFuncOwn\">";
 				while (!$users->EOF) {
 					$uname = $users->fields['usename'];
 					echo "<option value=\"", htmlspecialchars($uname), "\"",
@@ -224,9 +224,9 @@
 					$users->moveNext();
 				}
 				echo "</select>\n";
-			    echo "<input type=\"hidden\" name=\"original_owner\" value=\"", htmlspecialchars($fndata->fields['proowner']),"\" />\n";
-                            echo "</td></tr>\n";
-                        }
+				echo "<input type=\"hidden\" name=\"original_owner\" value=\"", htmlspecialchars($fndata->fields['proowner']),"\" />\n";
+				echo "</td></tr>\n";
+            }
 			echo "</table>\n";
 			echo "<p><input type=\"hidden\" name=\"action\" value=\"save_edit\" />\n";
 			echo "<input type=\"hidden\" name=\"function\" value=\"", htmlspecialchars($_REQUEST['function']), "\" />\n";
@@ -319,6 +319,7 @@
 				// Check to see if we have syntax highlighting for this language
 				if (isset($data->langmap[$funcdata->fields['prolanguage']])) {
 					$temp = syntax_highlight(htmlspecialchars($funcdata->fields['prosrc']), $data->langmap[$funcdata->fields['prolanguage']]);
+					$rawfunction = syntax_highlight(htmlspecialchars(str_replace(', OUT', ",\nOUT", $funcdata->fields['prodef'])), $data->langmap[$funcdata->fields['prolanguage']]);
 					$tag = 'prenoescape';
 				}
 				else {
@@ -326,6 +327,12 @@
 					$tag = 'pre';
 				}
 				echo "<tr><td class=\"data1\" colspan=\"4\">", $misc->printVal($temp, $tag, array('lineno' => true, 'class' => 'data1')), "</td></tr>\n";
+				
+				// Display raw definition if available
+				if (isset($rawfunction)) {
+					echo "<tr><th class=\"data\" colspan=\"4\">{$lang['strrawdefinition']}</th></tr>\n";
+					echo "<tr><td class=\"data1\" colspan=\"4\">", $misc->printVal($rawfunction, $tag, array('lineno' => true, 'class' => 'data1')), "</td></tr>\n";
+				}
 			}
 
 			// Display function cost options

--- a/lang/english.php
+++ b/lang/english.php
@@ -39,6 +39,7 @@
 	$lang['stractions'] = 'Actions';
 	$lang['strname'] = 'Name';
 	$lang['strdefinition'] = 'Definition';
+	$lang['strrawdefinition'] = 'Raw Definition';
 	$lang['strproperties'] = 'Properties';
 	$lang['strbrowse'] = 'Browse';
 	$lang['strenable'] = 'Enable';

--- a/lang/french.php
+++ b/lang/french.php
@@ -39,6 +39,7 @@
 	$lang['stractions'] = 'Actions';
 	$lang['strname'] = 'Nom';
 	$lang['strdefinition'] = 'Définition';
+	$lang['strrawdefinition'] = 'Définition brute';
 	$lang['strproperties'] = 'Propriétés';
 	$lang['strbrowse'] = 'Parcourir';
 	$lang['strenable'] = 'Activer';


### PR DESCRIPTION
The main problem I have with phppgadmin and that force me to use pgadmin3 is that I can't ALTER functions having OUT parameters.
Here is the problem when I try ALTER a function with phppgadmin that have OUT parameters :

ERROR:  cannot change return type of existing function
DETAIL:  Row type defined by OUT parameters is different.
HINT:  Use DROP FUNCTION test_function(character varying) first.
In statement:
CREATE OR REPLACE FUNCTION "public"."test_function" ("test" character varying) RETURNS SETOF record AS

With these changes, I can directly in phppgadmin copy and paste the function in the SQL window, make my changes and execute the query. Finally free of pgAdmin3 !

The changes I made are :
- Added a column to getFunction output in Postgres.php
- Added translation in English and French for "Raw Definition"
- Modified weird indentation in functions.php
- Added lines for displaying the raw definition

I know this is a walk-around to the main problem but it fixes a part of the problem right now.
The best fix would be to change the ALTER window so it takes in account the OUT parameters of a function.