### PR TITLE
fix SQL SCRIPT Partial execute

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -7524,6 +7524,7 @@ class Postgres extends ADODB_base {
     					    $query_buf .= "\n";
     					/* append the line to the query buffer */
     					$query_buf .= $subline;
+            			}
     					$query_buf .= ';';
 
 						// Execute the query. PHP cannot execute
@@ -7544,7 +7545,6 @@ class Postgres extends ADODB_base {
             					}
             				}
             			}
-            		}
 
 					$query_buf = null;
 					$query_start = $i + $thislen;


### PR DESCRIPTION
This is a fix for https://sourceforge.net/p/phppgadmin/bugs/448/ aka https://bugs.debian.org/762378

patch for fix error

if line started from or contain only semicolon ';' this code result is false

(strspn($subline, " \t\n\r") != strlen($subline)) 

anf  line $res = @pg_query($conn, $query_buf); 
not executed

function executeScript is called only for the processing  SQL script downloaded as file
