### PR TITLE
replaced old-style constructors (fixes php7 warnings)

### DIFF
--- a/classes/ArrayRecordSet.php
+++ b/classes/ArrayRecordSet.php
@@ -12,7 +12,7 @@ class ArrayRecordSet {
 	var $EOF = false;
 	var $fields;
 	
-	function ArrayRecordSet($data) {
+	function __construct($data) {
 		$this->_array = $data;
 		$this->_count = count($this->_array);
 		$this->fields = reset($this->_array);

--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -12,7 +12,7 @@
 		var $form;
 
 		/* Constructor */
-		function Misc() {
+		function __construct() {
 		}
 
 		/**

--- a/classes/class.select.php
+++ b/classes/class.select.php
@@ -24,7 +24,7 @@ class XHtmlSimpleElement {
 	* derived class
 	* 
 	*/
-	function XHtmlSimpleElement($element = null) {
+	function __construct($element = null) {
 
 		$this->_element = $this->is_element();
 		
@@ -93,7 +93,7 @@ class XHtmlElement extends XHtmlSimpleElement {
 	var $_htmlcode = "";
 	var $_siblings = array();
 
-	function XHtmlElement($text = null) {
+	function __construct($text = null) {
 		XHtmlSimpleElement::XHtmlSimpleElement();
 		
 		if ($text) $this->set_text($text);
@@ -159,7 +159,7 @@ class XHtmlElement extends XHtmlSimpleElement {
 }
 
 class XHTML_Button extends XHtmlElement {
-	function XHTML_Button ($name, $text = null) {
+	function __construct ($name, $text = null) {
 		parent::XHtmlElement();
 		
 		$this->set_attribute("name", $name);
@@ -170,7 +170,7 @@ class XHTML_Button extends XHtmlElement {
 
 
 class XHTML_Option extends XHtmlElement {
-	function XHTML_Option($text, $value = null) {
+	function __construct($text, $value = null) {
 		XHtmlElement::XHtmlElement(null);			
 		$this->set_text($text);
 	}
@@ -180,7 +180,7 @@ class XHTML_Option extends XHtmlElement {
 class XHTML_Select extends XHTMLElement {
 	var $_data;
 
-	function XHTML_Select ($name, $multiple = false, $size = null) {
+	function __construct ($name, $multiple = false, $size = null) {
 		XHtmlElement::XHtmlElement();					
 
 		$this->set_attribute("name", $name);

--- a/classes/database/ADODB_base.php
+++ b/classes/database/ADODB_base.php
@@ -20,7 +20,7 @@ class ADODB_base {
 	 * Base constructor
 	 * @param &$conn The connection object
 	 */
-	function ADODB_base(&$conn) {
+	function __construct(&$conn) {
 		$this->conn = $conn;
 	}
 

--- a/classes/database/Connection.php
+++ b/classes/database/Connection.php
@@ -19,7 +19,7 @@ class Connection {
 	 * Creates a new connection.  Will actually make a database connection.
 	 * @param $fetchMode Defaults to associative.  Override for different behaviour
 	 */
-	function Connection($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
+	function __construct($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
 		$this->conn = ADONewConnection('postgres7');
 		$this->conn->setFetchMode($fetchMode);
 

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -169,8 +169,8 @@ class Postgres extends ADODB_base {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres($conn) {
-		$this->ADODB_base($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Formatting functions

--- a/classes/database/Postgres93.php
+++ b/classes/database/Postgres93.php
@@ -15,8 +15,8 @@ class Postgres93 extends Postgres {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres93($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/libraries/adodb/adodb.inc.php
+++ b/libraries/adodb/adodb.inc.php
@@ -234,7 +234,7 @@
 	
 		var $createdir = true; // requires creation of temp dirs
 		
-		function ADODB_Cache_File()
+		function __construct()
 		{
 		global $ADODB_INCLUDED_CSV;
 			if (empty($ADODB_INCLUDED_CSV)) include_once(ADODB_DIR.'/adodb-csvlib.inc.php');
@@ -427,7 +427,7 @@
 	/**
 	 * Constructor
 	 */
-	function ADOConnection()			
+	function __construct()
 	{
 		die('Virtual Class -- cannot instantiate');
 	}
@@ -2657,7 +2657,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	/**
 	* Will select the supplied $page number from a recordset, given that it is paginated in pages of 
 	* $nrows rows per page. It also saves two boolean values saying if the given page is the first 
-	* and/or last one of the recordset. Added by Iván Oliva to provide recordset pagination.
+	* and/or last one of the recordset. Added by Ivï¿½n Oliva to provide recordset pagination.
 	*
 	* See readme.htm#ex8 for an example of usage.
 	*
@@ -2684,7 +2684,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	/**
 	* Will select the supplied $page number from a recordset, given that it is paginated in pages of 
 	* $nrows rows per page. It also saves two boolean values saying if the given page is the first 
-	* and/or last one of the recordset. Added by Iván Oliva to provide recordset pagination.
+	* and/or last one of the recordset. Added by Ivï¿½n Oliva to provide recordset pagination.
 	*
 	* @param secs2cache	seconds to cache data, set to 0 to force query
 	* @param sql
@@ -2883,9 +2883,9 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	var $_obj; 				/** Used by FetchObj */
 	var $_names;			/** Used by FetchObj */
 	
-	var $_currentPage = -1;	/** Added by Iván Oliva to implement recordset pagination */
-	var $_atFirstPage = false;	/** Added by Iván Oliva to implement recordset pagination */
-	var $_atLastPage = false;	/** Added by Iván Oliva to implement recordset pagination */
+	var $_currentPage = -1;	/** Added by Ivï¿½n Oliva to implement recordset pagination */
+	var $_atFirstPage = false;	/** Added by Ivï¿½n Oliva to implement recordset pagination */
+	var $_atLastPage = false;	/** Added by Ivï¿½n Oliva to implement recordset pagination */
 	var $_lastPageNo = -1; 
 	var $_maxRecordCount = 0;
 	var $datetime = false;
@@ -2896,7 +2896,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	 * @param queryID  	this is the queryID returned by ADOConnection->_query()
 	 *
 	 */
-	function ADORecordSet($queryID) 
+	function __construct($queryID)
 	{
 		$this->_queryID = $queryID;
 	}
@@ -3887,13 +3887,13 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		 * Constructor
 		 *
 		 */
-		function ADORecordSet_array($fakeid=1)
+		function __construct($fakeid=1)
 		{
 		global $ADODB_FETCH_MODE,$ADODB_COMPAT_FETCH;
 		
 			// fetch() on EOF does not delete $this->fields
 			$this->compat = !empty($ADODB_COMPAT_FETCH);
-			$this->ADORecordSet($fakeid); // fake queryID		
+			parent::__construct($fakeid); // fake queryID
 			$this->fetchMode = $ADODB_FETCH_MODE;
 		}
 		

--- a/libraries/adodb/drivers/adodb-postgres64.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres64.inc.php
@@ -873,7 +873,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 	var $_blobArr;
 	var $databaseType = "postgres64";
 	var $canSeek = true;
-	function ADORecordSet_postgres64($queryID,$mode=false) 
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -889,7 +889,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		default: $this->fetchMode = PGSQL_BOTH; break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 	
 	function GetRowAssoc($upper=true)

--- a/libraries/adodb/drivers/adodb-postgres7.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres7.inc.php
@@ -22,9 +22,9 @@ class ADODB_postgres7 extends ADODB_postgres64 {
 	var $ansiOuter = true;
 	var $charSet = true; //set to true for Postgres 7 and above - PG client supports encodings
 	
-	function ADODB_postgres7() 
+	function __construct()
 	{
-		$this->ADODB_postgres64();
+		parent::__construct();
 		if (ADODB_ASSOC_CASE !== 2) {
 			$this->rsPrefix .= 'assoc_';
 		}
@@ -215,9 +215,9 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 	var $databaseType = "postgres7";
 	
 	
-	function ADORecordSet_postgres7($queryID,$mode=false) 
+	function __construct($queryID,$mode=false)
 	{
-		$this->ADORecordSet_postgres64($queryID,$mode);
+		parent::__construct($queryID,$mode);
 	}
 	
 	 	// 10% speedup to move MoveNext to child class

--- a/libraries/decorator.inc.php
+++ b/libraries/decorator.inc.php
@@ -91,7 +91,7 @@ function value_url(&$var, &$fields) {
 
 class Decorator
 {
-	function Decorator($value) {
+	function __construct($value) {
 		$this->v = $value;
 	}
 	
@@ -102,7 +102,7 @@ class Decorator
 
 class FieldDecorator extends Decorator
 {
-	function FieldDecorator($fieldName, $default = null) {
+	function __construct($fieldName, $default = null) {
 		$this->f = $fieldName;
 		if ($default !== null) $this->d = $default;
 	}
@@ -114,7 +114,7 @@ class FieldDecorator extends Decorator
 
 class ArrayMergeDecorator extends Decorator
 {
-	function ArrayMergeDecorator($arrays) {
+	function __construct($arrays) {
 		$this->m = $arrays;
 	}
 	
@@ -129,7 +129,7 @@ class ArrayMergeDecorator extends Decorator
 
 class ConcatDecorator extends Decorator
 {
-	function ConcatDecorator($values) {
+	function __construct($values) {
 		$this->c = $values;
 	}
 	
@@ -144,7 +144,7 @@ class ConcatDecorator extends Decorator
 
 class CallbackDecorator extends Decorator
 {
-	function CallbackDecorator($callback, $param = null) {
+	function __construct($callback, $param = null) {
 		$this->fn = $callback;
 		$this->p = $param;
 	}
@@ -156,7 +156,7 @@ class CallbackDecorator extends Decorator
 
 class IfEmptyDecorator extends Decorator
 {
-	function IfEmptyDecorator($value, $empty, $full = null) {
+	function __construct($value, $empty, $full = null) {
 		$this->v = $value;
 		$this->e = $empty;
 		if ($full !== null) $this->f = $full;
@@ -173,7 +173,7 @@ class IfEmptyDecorator extends Decorator
 
 class UrlDecorator extends Decorator
 {
-	function UrlDecorator($base, $queryVars = null) {
+	function __construct($base, $queryVars = null) {
 		$this->b = $base;
 		if ($queryVars !== null)
 			$this->q = $queryVars;
@@ -199,7 +199,7 @@ class UrlDecorator extends Decorator
 
 class replaceDecorator extends Decorator
 {
-	function replaceDecorator($str, $params) {
+	function __construct($str, $params) {
 		$this->s = $str;
 		$this->p = $params;
 	}


### PR DESCRIPTION
Fixes "Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP..." messages
