### PR TITLE
See only databases to which the user can connect

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -476,7 +476,7 @@ class Postgres extends ADODB_base {
 				END as dbsize, pdb.datcollate, pdb.datctype
 			FROM pg_catalog.pg_database pdb
 				LEFT JOIN pg_catalog.pg_roles pr ON (pdb.datdba = pr.oid)
-			WHERE true
+			WHERE pg_catalog.has_database_privilege(current_user, pdb.oid, 'CONNECT') 
 				{$where}
 				{$clause}
 			{$orderby}";


### PR DESCRIPTION
It is useless to list all databases (given that if a user tries to click receives an error) and it could be a security breach.
Better to show only the databases to which the user can connect.