### PR TITLE
Remove "-i" flag from pg_dump

### DIFF
--- a/dbexport.php
+++ b/dbexport.php
@@ -72,8 +72,8 @@
 			putenv('PGPORT=' . $port);
 		}
 
-		// Build command for executing pg_dump.  '-i' means ignore version differences.
-		$cmd = $exe . " -i";
+		// Build command for executing pg_dump.
+		$cmd = $exe;
 		
 		// we are PG 7.4+, so we always have a schema
 		if (isset($_REQUEST['schema'])) {


### PR DESCRIPTION
With Postgres 9.5 (that is default on new Ubuntu LTS, so likely to spread soon) the `-i` option is causing an error, since it has been removed.
Anyway, such option has been deprecated since Postgres 8.4 (so about 6 years ago)