### PR TITLE
PHP 7 and PostgreSQL 10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+I have noticed some bugs when I use phppgadmin. I use PHP 7.1 and I got messages which indicate that using the same name for functions and classes is deprecated. I am trying to fix this bug.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-I have noticed some bugs when I use phppgadmin. I use PHP 7.1 and I got messages which indicate that using the same name for functions and classes is deprecated. I am trying to fix this bug.
+I have noticed some bugs when I use phppgadmin. I use PHP 7 and I got messages which indicate that using the same name for functions and classes is deprecated. This bug is normally fixed now.
+
+Furthermore, each() function is deprecated in PHP 7.2 ; I am correcting the code to make it compatible with this new version.

--- a/all_db.php
+++ b/all_db.php
@@ -191,21 +191,23 @@
 			}
 			$templatedbs->moveNext();
 		}
-		echo "\t\t\t</select>\n";
-		echo "\t\t</td>\n\t</tr>\n";
+	    echo "\t\t\t</select>\n";
+	    echo "\t\t</td>\n\t</tr>\n";
+	    
+	    // ENCODING
+	    echo "\t<tr>\n\t\t<th class=\"data left required\">{$lang['strencoding']}</th>\n";
+	    echo "\t\t<td class=\"data1\">\n";
+	    echo "\t\t\t<select name=\"formEncoding\">\n";
+	    echo "\t\t\t\t<option value=\"\"></option>\n";
 
-		// ENCODING
-		echo "\t<tr>\n\t\t<th class=\"data left required\">{$lang['strencoding']}</th>\n";
-		echo "\t\t<td class=\"data1\">\n";
-		echo "\t\t\t<select name=\"formEncoding\">\n";
-		echo "\t\t\t\t<option value=\"\"></option>\n";
-		while (list ($key) = each ($data->codemap)) {
-		    echo "\t\t\t\t<option value=\"", htmlspecialchars($key), "\"",
-				($key == $_POST['formEncoding']) ? ' selected="selected"' : '', ">",
-				$misc->printVal($key), "</option>\n";
-		}
-		echo "\t\t\t</select>\n";
-		echo "\t\t</td>\n\t</tr>\n";
+	    foreach($data->codemap as $key => $value) {
+		//while (list ($key) = each ($data->codemap)) {
+		echo "\t\t\t\t<option value=\"", htmlspecialchars($key), "\"",
+		($key == $_POST['formEncoding']) ? ' selected="selected"' : '', ">",
+		$misc->printVal($key), "</option>\n";
+	    }
+	    echo "\t\t\t</select>\n";
+	    echo "\t\t</td>\n\t</tr>\n";
 
 		if ($data->hasDatabaseCollation()) {
 			if (!isset($_POST['formCollate'])) $_POST['formCollate'] = '';

--- a/classes/ArrayRecordSet.php
+++ b/classes/ArrayRecordSet.php
@@ -12,7 +12,7 @@ class ArrayRecordSet {
 	var $EOF = false;
 	var $fields;
 	
-	function ArrayRecordSet($data) {
+	function __construct($data) {
 		$this->_array = $data;
 		$this->_count = count($this->_array);
 		$this->fields = reset($this->_array);

--- a/classes/Gui.php
+++ b/classes/Gui.php
@@ -9,7 +9,7 @@
 		/**
 		 *Constructor
 		 */
-		function GUI () {}
+		function __construct () {}
 		 
 		/**
 		 * Prints a combox box
@@ -21,7 +21,7 @@
 		 * @param (optional) $iSize int to specify the size IF a multi select combo
 		 * @return string with the generated HTML select box
 		 */
-		function printCombo(&$arrOptions, $szName, $bBlankEntry = true, $szDefault = '', $bMultiple = false, $iSize = 10) {
+		static function printCombo(&$arrOptions, $szName, $bBlankEntry = true, $szDefault = '', $bMultiple = false, $iSize = 10) {
 			$htmlOut = '';
 			if ($bMultiple) // If multiple select combo
 				$htmlOut .= "<select name=\"$szName\" id=\"$szName\" multiple=\"multiple\" size=\"$iSize\">\n";

--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -12,7 +12,7 @@
 		var $form;
 
 		/* Constructor */
-		function Misc() {
+		function __construct() {
 		}
 
 		/**

--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -1443,7 +1443,7 @@
 				</script>";
 			}
 			else {
-				echo "<span class=\"appname\">{$appName}</span> <span class=\"version\">{$appVersion}</span>";
+				echo "<span class=\"appname\">{$appName}</span> <span class=\"version\">{$appVersion} (PHP ".phpversion().")</span>";
 			}
 /*
 			echo "<td style=\"text-align: right; width: 1%\">";

--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -477,32 +477,32 @@
 			}
 
 			// Create the connection object and make the connection
-			$_connection = new Connection(
-				$server_info['host'],
-				$server_info['port'],
-				$server_info['sslmode'],
-				$server_info['username'],
-				$server_info['password'],
-				$database
-			);
-
-			// Get the name of the database driver we need to use.
-			// The description of the server is returned in $platform.
-			$_type = $_connection->getDriver($platform);
-			if ($_type === null) {
-				printf($lang['strpostgresqlversionnotsupported'], $postgresqlMinVer);
-				exit;
+		    $_connection = new Connection(
+			$server_info['host'],
+			$server_info['port'],
+			$server_info['sslmode'],
+			$server_info['username'],
+			$server_info['password'],
+			$database
+		    );
+		    
+		    // Get the name of the database driver we need to use.
+		    // The description of the server is returned in $platform.
+		    $_type = $_connection->getDriver($platform);
+		    if ($_type === null) {
+			    printf($lang['strpostgresqlversionnotsupported'], $postgresqlMinVer);
+			    exit;
 			}
-			$this->setServerInfo('platform', $platform, $server_id);
-			$this->setServerInfo('pgVersion', $_connection->conn->pgVersion, $server_id);
-
-			// Create a database wrapper class for easy manipulation of the
-			// connection.
-			include_once('./classes/database/' . $_type . '.php');
-			$data = new $_type($_connection->conn);
-			$data->platform = $_connection->platform;
-
-			/* we work on UTF-8 only encoding */
+		    $this->setServerInfo('platform', $platform, $server_id);
+		    $this->setServerInfo('pgVersion', $_connection->conn->pgVersion, $server_id);
+		    
+		    // Create a database wrapper class for easy manipulation of the
+		    // connection.
+		    include_once('./classes/database/' . $_type . '.php');
+		    $data = new $_type($_connection->conn);
+		    $data->platform = $_connection->platform;
+		    
+		    /* we work on UTF-8 only encoding */
 			$data->execute("SET client_encoding TO 'UTF-8'");
 
 			if ($data->hasByteaHexDefault()) {

--- a/classes/class.select.php
+++ b/classes/class.select.php
@@ -24,7 +24,7 @@ class XHtmlSimpleElement {
 	* derived class
 	* 
 	*/
-	function XHtmlSimpleElement($element = null) {
+	function __construct($element = null) {
 
 		$this->_element = $this->is_element();
 		
@@ -93,8 +93,8 @@ class XHtmlElement extends XHtmlSimpleElement {
 	var $_htmlcode = "";
 	var $_siblings = array();
 
-	function XHtmlElement($text = null) {
-		XHtmlSimpleElement::XHtmlSimpleElement();
+	function __construct($text = null) {
+		parent::__construct();
 		
 		if ($text) $this->set_text($text);
 	}
@@ -159,8 +159,8 @@ class XHtmlElement extends XHtmlSimpleElement {
 }
 
 class XHTML_Button extends XHtmlElement {
-	function XHTML_Button ($name, $text = null) {
-		parent::XHtmlElement();
+	function __construct($name, $text = null) {
+		parent::__construct();
 		
 		$this->set_attribute("name", $name);
 		
@@ -170,8 +170,8 @@ class XHTML_Button extends XHtmlElement {
 
 
 class XHTML_Option extends XHtmlElement {
-	function XHTML_Option($text, $value = null) {
-		XHtmlElement::XHtmlElement(null);			
+	function __construct($text, $value = null) {
+		parent::__construct(null);			
 		$this->set_text($text);
 	}
 }
@@ -180,8 +180,8 @@ class XHTML_Option extends XHtmlElement {
 class XHTML_Select extends XHTMLElement {
 	var $_data;
 
-	function XHTML_Select ($name, $multiple = false, $size = null) {
-		XHtmlElement::XHtmlElement();					
+	function __construct($name, $multiple = false, $size = null) {
+		parent::__construct();					
 
 		$this->set_attribute("name", $name);
 		if ($multiple) $this->set_attribute("multiple","multiple");
@@ -206,7 +206,11 @@ class XHTML_Select extends XHTMLElement {
 	
 	function fetch() {
 		if (isset($this->_data) && $this->_data) {
-			foreach ($this->_data as $value) { $this->add(new XHTML_Option($value)); }
+			foreach ($this->_data as $value) { 
+				$XHTML_Opt = new XHTML_Option($value);
+				$this->add($XHTML_Opt);
+				//$this->add(new XHTML_Option($value)); 
+			}
 		}
 		return parent::fetch();
 	}

--- a/classes/database/ADODB_base.php
+++ b/classes/database/ADODB_base.php
@@ -20,7 +20,7 @@ class ADODB_base {
 	 * Base constructor
 	 * @param &$conn The connection object
 	 */
-	function ADODB_base(&$conn) {
+	function __construct(&$conn) {
 		$this->conn = $conn;
 	}
 

--- a/classes/database/ADODB_base.php
+++ b/classes/database/ADODB_base.php
@@ -57,12 +57,13 @@ class ADODB_base {
 	 * @param $arr The array to clean, by reference
 	 * @return The cleaned array
 	 */
-	function arrayClean(&$arr) {
-		reset($arr);
-		while(list($k, $v) = each($arr))
-			$arr[$k] = addslashes($v);
-		return $arr;
-	}
+    function arrayClean(&$arr) {
+	reset($arr);
+	//while(list($k, $v) = each($arr))
+	foreach ($arr as $k => $v)
+	$arr[$k] = addslashes($v);
+	return $arr;
+    }
 	
 	/**
 	 * Executes a query on the underlying connection
@@ -141,12 +142,13 @@ class ADODB_base {
 
 		// Build clause
 		$sql = '';
-		while(list($key, $value) = each($conditions)) {
-			$this->clean($key);
-			$this->clean($value);
-			if ($sql) $sql .= " AND \"{$key}\"='{$value}'";
-			else $sql = "DELETE FROM {$schema}\"{$table}\" WHERE \"{$key}\"='{$value}'";
-		}
+	    foreach ($conditions as $key => $value) {
+		//while(list($key, $value) = each($conditions)) {
+		$this->clean($key);
+		$this->clean($value);
+		    if ($sql) $sql .= " AND \"{$key}\"='{$value}'";
+		else $sql = "DELETE FROM {$schema}\"{$table}\" WHERE \"{$key}\"='{$value}'";
+	    }
 
 		// Check for failures
 		if (!$this->conn->Execute($sql)) {
@@ -221,37 +223,41 @@ class ADODB_base {
 
 		// Populate the syntax arrays
 		reset($vars);
-		while(list($key, $value) = each($vars)) {
-			$this->fieldClean($key);
-			$this->clean($value);
-			if ($setClause) $setClause .= ", \"{$key}\"='{$value}'";
-			else $setClause = "UPDATE \"{$table}\" SET \"{$key}\"='{$value}'";
-		}
+	    foreach ($vars as $key => $value) {
+		//while(list($key, $value) = each($vars)) {
+		$this->fieldClean($key);
+		$this->clean($value);
+		if ($setClause) $setClause .= ", \"{$key}\"='{$value}'";
+		else $setClause = "UPDATE \"{$table}\" SET \"{$key}\"='{$value}'";
+	    }
 
-		reset($nulls);
-		while(list(, $value) = each($nulls)) {
-			$this->fieldClean($value);
-			if ($setClause) $setClause .= ", \"{$value}\"=NULL";
-			else $setClause = "UPDATE \"{$table}\" SET \"{$value}\"=NULL";
-		}
+	    reset($nulls);
+	    foreach ($nulls as $value) {
+	    //while(list(, $value) = each($nulls)) {
+		$this->fieldClean($value);
+		if ($setClause) $setClause .= ", \"{$value}\"=NULL";
+		else $setClause = "UPDATE \"{$table}\" SET \"{$value}\"=NULL";
+	    }
 
-		reset($where);
-		while(list($key, $value) = each($where)) {
-			$this->fieldClean($key);
-			$this->clean($value);
-			if ($whereClause) $whereClause .= " AND \"{$key}\"='{$value}'";
-			else $whereClause = " WHERE \"{$key}\"='{$value}'";
-		}
-
-		// Check for failures
-		if (!$this->conn->Execute($setClause . $whereClause)) {
-			// Check for unique constraint failure
-			if (stristr($this->conn->ErrorMsg(), 'unique'))
-				return -1;
+	    reset($where);
+	    
+	    foreach ($where as $key => $value) {
+		//while(list($key, $value) = each($where)) {
+		$this->fieldClean($key);
+		$this->clean($value);
+		if ($whereClause) $whereClause .= " AND \"{$key}\"='{$value}'";
+		else $whereClause = " WHERE \"{$key}\"='{$value}'";
+	    }
+	    
+	    // Check for failures
+	    if (!$this->conn->Execute($setClause . $whereClause)) {
+		// Check for unique constraint failure
+		if (stristr($this->conn->ErrorMsg(), 'unique'))
+		    return -1;
 			// Check for referential integrity failure
-			elseif (stristr($this->conn->ErrorMsg(), 'referential'))
-				return -2;
-		}
+		elseif (stristr($this->conn->ErrorMsg(), 'referential'))
+		return -2;
+	    }
 
 		// Check for no rows modified
 		if ($this->conn->Affected_Rows() == 0) return -3;

--- a/classes/database/Connection.php
+++ b/classes/database/Connection.php
@@ -19,7 +19,7 @@ class Connection {
 	 * Creates a new connection.  Will actually make a database connection.
 	 * @param $fetchMode Defaults to associative.  Override for different behaviour
 	 */
-	function Connection($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
+	function __construct($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
 		$this->conn = ADONewConnection('postgres7');
 		$this->conn->setFetchMode($fetchMode);
 

--- a/classes/database/Connection.php
+++ b/classes/database/Connection.php
@@ -20,7 +20,7 @@ class Connection {
 	 * @param $fetchMode Defaults to associative.  Override for different behaviour
 	 */
 	function __construct($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
-		$this->conn = ADONewConnection('postgres7');
+		$this->conn = ADONewConnection('postgres');
 		$this->conn->setFetchMode($fetchMode);
 
 		// Ignore host if null
@@ -92,8 +92,8 @@ class Connection {
 		case '7.4': return 'Postgres74'; break;
 	    }
 
-	    switch (substr($version,0,4)) {
-		case '10.0': return 'Postgres100'; break;
+	    switch (substr($version,0,2)) {
+		case '10': return 'Postgres10'; break;
 	    }
 
 	    /* All <7.4 versions are not supported */

--- a/classes/database/Connection.php
+++ b/classes/database/Connection.php
@@ -74,31 +74,36 @@ class Connection {
 		
 		$description = "PostgreSQL {$version}";
 
-		// Detect version and choose appropriate database driver
-		switch (substr($version,0,3)) {
-                        case '9.5': return 'Postgres'; break;
-			case '9.4': return 'Postgres94'; break;
-			case '9.3': return 'Postgres93'; break;
-			case '9.2': return 'Postgres92'; break;
-			case '9.1': return 'Postgres91'; break;
-			case '9.0': return 'Postgres90'; break;
-			case '8.4': return 'Postgres84'; break;
-			case '8.3': return 'Postgres83'; break;
-			case '8.2': return 'Postgres82'; break;
-			case '8.1': return 'Postgres81'; break;
-			case '8.0':
-			case '7.5': return 'Postgres80'; break;
-			case '7.4': return 'Postgres74'; break;
-		}
+	    // Detect version and choose appropriate database driver
+	    switch (substr($version,0,3)) {
+		    
+		case '9.6': return 'Postgres96'; break;
+                case '9.5': return 'Postgres95'; break;
+		case '9.4': return 'Postgres94'; break;
+		case '9.3': return 'Postgres93'; break;
+		case '9.2': return 'Postgres92'; break;
+		case '9.1': return 'Postgres91'; break;
+		case '9.0': return 'Postgres90'; break;
+		case '8.4': return 'Postgres84'; break;
+		case '8.3': return 'Postgres83'; break;
+		case '8.2': return 'Postgres82'; break;
+		case '8.1': return 'Postgres81'; break;
+		case '8.0': return 'Postgres80'; break;
+		case '7.4': return 'Postgres74'; break;
+	    }
 
-		/* All <7.4 versions are not supported */
-		// if major version is 7 or less and wasn't cought in the
-		// switch/case block, we have an unsupported version.
-		if ((int)substr($version, 0, 1) < 8)
-			return null;
+	    switch (substr($version,0,4)) {
+		case '10.0': return 'Postgres100'; break;
+	    }
 
-		// If unknown version, then default to latest driver
-		return 'Postgres';
+	    /* All <7.4 versions are not supported */
+	    // if major version is 7 or less and wasn't cought in the
+	    // switch/case block, we have an unsupported version.
+	    if ((int)substr($version, 0, 1) < 8 && (int) substr($version,0,2) < 10) {
+		return null;
+	    }
+	    // If unknown version, then default to latest driver
+	    return 'Postgres';
 
 	}
 

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -169,8 +169,8 @@ class Postgres extends ADODB_base {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres($conn) {
-		$this->ADODB_base($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Formatting functions

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -476,7 +476,7 @@ class Postgres extends ADODB_base {
 				END as dbsize, pdb.datcollate, pdb.datctype
 			FROM pg_catalog.pg_database pdb
 				LEFT JOIN pg_catalog.pg_roles pr ON (pdb.datdba = pr.oid)
-			WHERE true
+			WHERE pg_catalog.has_database_privilege(current_user, pdb.oid, 'CONNECT')
 				{$where}
 				{$clause}
 			{$orderby}";

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -11,7 +11,7 @@ include_once('./classes/database/ADODB_base.php');
 
 class Postgres extends ADODB_base {
 
-	var $major_version = 10.0;
+	var $major_version = 10;
 	// Max object name length
 	var $_maxNameLen = 63;
 	// Store the current schema

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -11,7 +11,7 @@ include_once('./classes/database/ADODB_base.php');
 
 class Postgres extends ADODB_base {
 
-	var $major_version = 9.5;
+	var $major_version = 10.0;
 	// Max object name length
 	var $_maxNameLen = 63;
 	// Store the current schema

--- a/classes/database/Postgres10.php
+++ b/classes/database/Postgres10.php
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * PostgreSQL 10.0 support
+ * PostgreSQL 10 support
  *
  */
 
 include_once('./classes/database/Postgres.php');
 
-class Postgres100 extends Postgres {
+class Postgres10 extends Postgres {
 
-	var $major_version = 10.0;
+	var $major_version = 10;
 
 	/**
 	 * Constructor
@@ -22,7 +22,7 @@ class Postgres100 extends Postgres {
 	// Help functions
 
 	function getHelpPages() {
-		include_once('./help/PostgresDoc100.php');
+		include_once('./help/PostgresDoc10.php');
 		return $this->help_page;
 	}
 

--- a/classes/database/Postgres100.php
+++ b/classes/database/Postgres100.php
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * PostgreSQL 9.2 support
+ * PostgreSQL 10.0 support
  *
  */
 
-include_once('./classes/database/Postgres93.php');
+include_once('./classes/database/Postgres.php');
 
-class Postgres92 extends Postgres93 {
+class Postgres100 extends Postgres {
 
-	var $major_version = 9.2;
+	var $major_version = 10.0;
 
 	/**
 	 * Constructor
@@ -22,7 +22,7 @@ class Postgres92 extends Postgres93 {
 	// Help functions
 
 	function getHelpPages() {
-		include_once('./help/PostgresDoc92.php');
+		include_once('./help/PostgresDoc100.php');
 		return $this->help_page;
 	}
 

--- a/classes/database/Postgres74.php
+++ b/classes/database/Postgres74.php
@@ -29,8 +29,8 @@ class Postgres74 extends Postgres80 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres74($conn) {
-		$this->Postgres80($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres80.php
+++ b/classes/database/Postgres80.php
@@ -50,8 +50,8 @@ class Postgres80 extends Postgres81 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres80($conn) {
-		$this->Postgres81($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres81.php
+++ b/classes/database/Postgres81.php
@@ -45,8 +45,8 @@ class Postgres81 extends Postgres82 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres81($conn) {
-		$this->Postgres82($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres82.php
+++ b/classes/database/Postgres82.php
@@ -22,8 +22,8 @@ class Postgres82 extends Postgres83 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres82($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres83.php
+++ b/classes/database/Postgres83.php
@@ -45,8 +45,8 @@ class Postgres83 extends Postgres84 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres83($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres84.php
+++ b/classes/database/Postgres84.php
@@ -30,8 +30,8 @@ class Postgres84 extends Postgres90 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres84($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres90.php
+++ b/classes/database/Postgres90.php
@@ -16,8 +16,8 @@ class Postgres90 extends Postgres91 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres90($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres91.php
+++ b/classes/database/Postgres91.php
@@ -16,8 +16,8 @@ class Postgres91 extends Postgres92 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres91($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres93.php
+++ b/classes/database/Postgres93.php
@@ -15,8 +15,8 @@ class Postgres93 extends Postgres94 {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres93($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres94.php
+++ b/classes/database/Postgres94.php
@@ -5,9 +5,9 @@
  *
  */
 
-include_once('./classes/database/Postgres.php');
+include_once('./classes/database/Postgres95.php');
 
-class Postgres94 extends Postgres {
+class Postgres94 extends Postgres95 {
 
 	var $major_version = 9.4;
 
@@ -15,8 +15,8 @@ class Postgres94 extends Postgres {
 	 * Constructor
 	 * @param $conn The database connection
 	 */
-	function Postgres94($conn) {
-		$this->Postgres($conn);
+	function __construct($conn) {
+		parent::__construct($conn);
 	}
 
 	// Help functions

--- a/classes/database/Postgres95.php
+++ b/classes/database/Postgres95.php
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * PostgreSQL 9.2 support
+ * PostgreSQL 9.5 support
  *
  */
 
-include_once('./classes/database/Postgres93.php');
+include_once('./classes/database/Postgres96.php');
 
-class Postgres92 extends Postgres93 {
+class Postgres95 extends Postgres96 {
 
-	var $major_version = 9.2;
+	var $major_version = 9.5;
 
 	/**
 	 * Constructor
@@ -22,7 +22,7 @@ class Postgres92 extends Postgres93 {
 	// Help functions
 
 	function getHelpPages() {
-		include_once('./help/PostgresDoc92.php');
+		include_once('./help/PostgresDoc95.php');
 		return $this->help_page;
 	}
 

--- a/classes/database/Postgres96.php
+++ b/classes/database/Postgres96.php
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * PostgreSQL 9.2 support
+ * PostgreSQL 9.6 support
  *
  */
 
-include_once('./classes/database/Postgres93.php');
+include_once('./classes/database/Postgres100.php');
 
-class Postgres92 extends Postgres93 {
+class Postgres96 extends Postgres100 {
 
-	var $major_version = 9.2;
+	var $major_version = 9.6;
 
 	/**
 	 * Constructor
@@ -22,7 +22,7 @@ class Postgres92 extends Postgres93 {
 	// Help functions
 
 	function getHelpPages() {
-		include_once('./help/PostgresDoc92.php');
+		include_once('./help/PostgresDoc96.php');
 		return $this->help_page;
 	}
 

--- a/classes/database/Postgres96.php
+++ b/classes/database/Postgres96.php
@@ -5,9 +5,9 @@
  *
  */
 
-include_once('./classes/database/Postgres100.php');
+include_once('./classes/database/Postgres10.php');
 
-class Postgres96 extends Postgres100 {
+class Postgres96 extends Postgres10 {
 
 	var $major_version = 9.6;
 

--- a/constraints.php
+++ b/constraints.php
@@ -158,7 +158,9 @@
 
 				if ($attrs->recordCount() > 0) {
 					while (!$attrs->EOF) {
-						$selColumns->add(new XHTML_Option($attrs->fields['attname']));
+						$XHTML_Opt = new XHTML_Option($attrs->fields['attname']);
+						$selColumns->add($XHTML_Opt);
+						//$selColumns->add(new XHTML_Option($attrs->fields['attname']));
 						$attrs->moveNext();
 					}
 				}
@@ -251,7 +253,9 @@
 
 			if ($attrs->recordCount() > 0) {
 				while (!$attrs->EOF) {
-					$selColumns->add(new XHTML_Option($attrs->fields['attname']));
+					$XHTML_Opt = new XHTML_Option($attrs->fields['attname']);
+					$selColumns->add($XHTML_Opt);
+					//$selColumns->add(new XHTML_Option($attrs->fields['attname']));
 					$attrs->moveNext();
 				}
 			}

--- a/help/PostgresDoc10.php
+++ b/help/PostgresDoc10.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * Help links for PostgreSQL 10.0 documentation
+ * Help links for PostgreSQL 10 documentation
  *
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
 include('./help/PostgresDoc96.php');
 
-$this->help_base = sprintf($GLOBALS['conf']['help_base'], '10.0');
+$this->help_base = sprintf($GLOBALS['conf']['help_base'], '10');
 
 ?>

--- a/help/PostgresDoc100.php
+++ b/help/PostgresDoc100.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Help links for PostgreSQL 10.0 documentation
+ *
+ * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
+ */
+
+include('./help/PostgresDoc96.php');
+
+$this->help_base = sprintf($GLOBALS['conf']['help_base'], '10.0');
+
+?>

--- a/help/PostgresDoc96.php
+++ b/help/PostgresDoc96.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Help links for PostgreSQL 9.6 documentation
+ *
+ * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
+ */
+
+include('./help/PostgresDoc95.php');
+
+$this->help_base = sprintf($GLOBALS['conf']['help_base'], '9.6');
+
+?>

--- a/indexes.php
+++ b/indexes.php
@@ -91,7 +91,9 @@
 
 		if ($attrs->recordCount() > 0) {
 			while (!$attrs->EOF) {
-				$selColumns->add(new XHTML_Option($attrs->fields['attname']));
+				$XHTML_Opt = new XHTML_Option($attrs->fields['attname']);
+				$selColumns->add($XHTML_Opt);
+				//$selColumns->add(new XHTML_Option($attrs->fields['attname']));
 				$attrs->moveNext();
 			}
 		}

--- a/libraries/adodb/adodb-datadict.inc.php
+++ b/libraries/adodb/adodb-datadict.inc.php
@@ -518,7 +518,7 @@ class ADODB_DataDict {
 			list($lines,$pkey,$idxs) = $this->_GenFields($flds);
 			// genfields can return FALSE at times
 			if ($lines == null) $lines = array();
-			list(,$first) = each($lines);
+			list(,$first) = array_values($lines); //each deprecated in php 7.2
 			list(,$column_def) = preg_split("/[\t ]+/",$first,2);
 		}
 		return array(sprintf($this->renameColumn,$tabname,$this->NameQuote($oldcolumn),$this->NameQuote($newcolumn),$column_def));

--- a/libraries/adodb/adodb-error.inc.php
+++ b/libraries/adodb/adodb-error.inc.php
@@ -102,8 +102,9 @@ function adodb_error_pg($errormsg)
 			'/Relation [\"\'].*[\"\'] already exists|Cannot insert a duplicate key into (a )?unique index.*|duplicate key.*violates unique constraint/i'     
 			 	 => DB_ERROR_ALREADY_EXISTS
         );
-	reset($error_regexps);
-    while (list($regexp,$code) = each($error_regexps)) {
+    reset($error_regexps);
+    foreach ($error_regexps as $regexp => $code) {
+	//while (list($regexp,$code) = each($error_regexps)) { // deprecated in php 7.2
         if (preg_match($regexp, $errormsg)) {
             return $code;
         }

--- a/libraries/adodb/adodb.inc.php
+++ b/libraries/adodb/adodb.inc.php
@@ -958,25 +958,26 @@
 			unset($element0);
 			
 			if (!is_array($sql) && !$this->_bindInputArray) {
-				$sqlarr = explode('?',$sql);
-				$nparams = sizeof($sqlarr)-1;
-				if (!$array_2d) $inputarr = array($inputarr);
-				foreach($inputarr as $arr) {
-					$sql = ''; $i = 0;
-					//Use each() instead of foreach to reduce memory usage -mikefedyk
-					while(list(, $v) = each($arr)) {
-						$sql .= $sqlarr[$i];
-						// from Ron Baldwin <ron.baldwin#sourceprose.com>
-						// Only quote string types	
-						$typ = gettype($v);
-						if ($typ == 'string')
-							//New memory copy of input created here -mikefedyk
-							$sql .= $this->qstr($v);
-						else if ($typ == 'double')
-							$sql .= str_replace(',','.',$v); // locales fix so 1.1 does not get converted to 1,1
-						else if ($typ == 'boolean')
-							$sql .= $v ? $this->true : $this->false;
-						else if ($typ == 'object') {
+			    $sqlarr = explode('?',$sql);
+			    $nparams = sizeof($sqlarr)-1;
+			    if (!$array_2d) $inputarr = array($inputarr);
+			    foreach($inputarr as $arr) {
+				$sql = ''; $i = 0;
+				//Use each() instead of foreach to reduce memory usage -mikefedyk
+				foreach($arr as $v) {
+				//while(list(, $v) = each($arr)) {
+				    $sql .= $sqlarr[$i];
+				    // from Ron Baldwin <ron.baldwin#sourceprose.com>
+				    // Only quote string types	
+				    $typ = gettype($v);
+				    if ($typ == 'string')
+					//New memory copy of input created here -mikefedyk
+					$sql .= $this->qstr($v);
+				    else if ($typ == 'double')
+				    $sql .= str_replace(',','.',$v); // locales fix so 1.1 does not get converted to 1,1
+				    else if ($typ == 'boolean')
+				    $sql .= $v ? $this->true : $this->false;
+				    else if ($typ == 'object') {
 							if (method_exists($v, '__toString')) $sql .= $this->qstr($v->__toString());
 							else $sql .= $this->qstr((string) $v);
 						} else if ($v === null)

--- a/libraries/adodb/adodb.inc.php
+++ b/libraries/adodb/adodb.inc.php
@@ -234,7 +234,7 @@
 	
 		var $createdir = true; // requires creation of temp dirs
 		
-		function ADODB_Cache_File()
+		function __construct()
 		{
 		global $ADODB_INCLUDED_CSV;
 			if (empty($ADODB_INCLUDED_CSV)) include_once(ADODB_DIR.'/adodb-csvlib.inc.php');
@@ -427,7 +427,7 @@
 	/**
 	 * Constructor
 	 */
-	function ADOConnection()			
+	function __construct()			
 	{
 		die('Virtual Class -- cannot instantiate');
 	}
@@ -2896,7 +2896,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	 * @param queryID  	this is the queryID returned by ADOConnection->_query()
 	 *
 	 */
-	function ADORecordSet($queryID) 
+	function __construct($queryID) 
 	{
 		$this->_queryID = $queryID;
 	}
@@ -3887,13 +3887,13 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		 * Constructor
 		 *
 		 */
-		function ADORecordSet_array($fakeid=1)
+		function __construct($fakeid=1)
 		{
 		global $ADODB_FETCH_MODE,$ADODB_COMPAT_FETCH;
 		
 			// fetch() on EOF does not delete $this->fields
 			$this->compat = !empty($ADODB_COMPAT_FETCH);
-			$this->ADORecordSet($fakeid); // fake queryID		
+			parent::__construct($fakeid); // fake queryID		
 			$this->fetchMode = $ADODB_FETCH_MODE;
 		}
 		

--- a/libraries/adodb/drivers/adodb-postgres64.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres64.inc.php
@@ -873,7 +873,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 	var $_blobArr;
 	var $databaseType = "postgres64";
 	var $canSeek = true;
-	function ADORecordSet_postgres64($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -889,7 +889,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		default: $this->fetchMode = PGSQL_BOTH; break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 	
 	function GetRowAssoc($upper=true)

--- a/libraries/adodb/drivers/adodb-postgres7.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres7.inc.php
@@ -22,9 +22,9 @@ class ADODB_postgres7 extends ADODB_postgres64 {
 	var $ansiOuter = true;
 	var $charSet = true; //set to true for Postgres 7 and above - PG client supports encodings
 	
-	function ADODB_postgres7() 
+	function __construct() 
 	{
-		$this->ADODB_postgres64();
+		parent::__construct();
 		if (ADODB_ASSOC_CASE !== 2) {
 			$this->rsPrefix .= 'assoc_';
 		}
@@ -215,9 +215,9 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 	var $databaseType = "postgres7";
 	
 	
-	function ADORecordSet_postgres7($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
-		$this->ADORecordSet_postgres64($queryID,$mode);
+		parent::__construct($queryID,$mode);
 	}
 	
 	 	// 10% speedup to move MoveNext to child class

--- a/libraries/adodb/toexport.inc.php
+++ b/libraries/adodb/toexport.inc.php
@@ -71,22 +71,23 @@ function _adodb_export(&$rs,$sep,$sepreplace,$fp=false,$addtitles=true,$quote = 
 	$s = '';
 	
 	if ($addtitles) {
-		$fieldTypes = $rs->FieldTypesArray();
-		reset($fieldTypes);
-		$i = 0;
-		while(list(,$o) = each($fieldTypes)) {
+	    $fieldTypes = $rs->FieldTypesArray();
+	    reset($fieldTypes);
+	    $i = 0;
+	    foreach ($fieldTypes as $o) {
+		// while(list(,$o) = each($fieldTypes)) {
 		
-			$v = ($o) ? $o->name : 'Field'.($i++);
-			if ($escquote) $v = str_replace($quote,$escquotequote,$v);
-			$v = strip_tags(str_replace("\n", $replaceNewLine, str_replace("\r\n",$replaceNewLine,str_replace($sep,$sepreplace,$v))));
-			$elements[] = $v;
-			
-		}
-		$s .= implode($sep, $elements).$NEWLINE;
+		$v = ($o) ? $o->name : 'Field'.($i++);
+		if ($escquote) $v = str_replace($quote,$escquotequote,$v);
+		$v = strip_tags(str_replace("\n", $replaceNewLine, str_replace("\r\n",$replaceNewLine,str_replace($sep,$sepreplace,$v))));
+		$elements[] = $v;
+		
+	    }
+	    $s .= implode($sep, $elements).$NEWLINE;
 	}
-	$hasNumIndex = isset($rs->fields[0]);
-	
-	$line = 0;
+    $hasNumIndex = isset($rs->fields[0]);
+    
+    $line = 0;
 	$max = $rs->FieldCount();
 	
 	while (!$rs->EOF) {

--- a/libraries/decorator.inc.php
+++ b/libraries/decorator.inc.php
@@ -91,7 +91,7 @@ function value_url(&$var, &$fields) {
 
 class Decorator
 {
-	function Decorator($value) {
+	function __construct($value) {
 		$this->v = $value;
 	}
 	
@@ -102,7 +102,7 @@ class Decorator
 
 class FieldDecorator extends Decorator
 {
-	function FieldDecorator($fieldName, $default = null) {
+	function __construct($fieldName, $default = null) {
 		$this->f = $fieldName;
 		if ($default !== null) $this->d = $default;
 	}
@@ -114,7 +114,7 @@ class FieldDecorator extends Decorator
 
 class ArrayMergeDecorator extends Decorator
 {
-	function ArrayMergeDecorator($arrays) {
+	function __construct($arrays) {
 		$this->m = $arrays;
 	}
 	
@@ -129,7 +129,7 @@ class ArrayMergeDecorator extends Decorator
 
 class ConcatDecorator extends Decorator
 {
-	function ConcatDecorator($values) {
+	function __construct($values) {
 		$this->c = $values;
 	}
 	
@@ -144,7 +144,7 @@ class ConcatDecorator extends Decorator
 
 class CallbackDecorator extends Decorator
 {
-	function CallbackDecorator($callback, $param = null) {
+	function __construct($callback, $param = null) {
 		$this->fn = $callback;
 		$this->p = $param;
 	}
@@ -156,7 +156,7 @@ class CallbackDecorator extends Decorator
 
 class IfEmptyDecorator extends Decorator
 {
-	function IfEmptyDecorator($value, $empty, $full = null) {
+	function __construct($value, $empty, $full = null) {
 		$this->v = $value;
 		$this->e = $empty;
 		if ($full !== null) $this->f = $full;
@@ -173,7 +173,7 @@ class IfEmptyDecorator extends Decorator
 
 class UrlDecorator extends Decorator
 {
-	function UrlDecorator($base, $queryVars = null) {
+	function __construct($base, $queryVars = null) {
 		$this->b = $base;
 		if ($queryVars !== null)
 			$this->q = $queryVars;
@@ -199,7 +199,7 @@ class UrlDecorator extends Decorator
 
 class replaceDecorator extends Decorator
 {
-	function replaceDecorator($str, $params) {
+	function __construct($str, $params) {
 		$this->s = $str;
 		$this->p = $params;
 	}

--- a/triggers.php
+++ b/triggers.php
@@ -181,7 +181,9 @@
 		/* Populate functions */
 		$sel0 = new XHTML_Select('formFunction');
 		while (!$funcs->EOF) {
-			$sel0->add(new XHTML_Option($funcs->fields['proname']));
+			$XHTML_Opt = new XHTML_Option($funcs->fields['proname']);
+			$sel0->add($XHTML_Opt);
+			//$sel0->add(new XHTML_Option($funcs->fields['proname']));
 			$funcs->moveNext();
 		}
 


### PR DESCRIPTION
In this code, I found several classes where the constructor function had the same name than the class. That is deprecated in PHP 7, and when I test this version on my machine, I get warning messages. The good way to define a constructor is to use the name __construct for the constructor.

Furthermore, the version 10 of PostgreSQL was released few months ago, and phpPgAdmin was not compatible with this new version of PgSQL, so I corrected this problem.

function each() is not compatible with PHP 7.2, which was released few days ago, so I also corrected this.

PS : Sorry if I submit my pull request again, but I had some problems with my old repository and I had to create it again.