### PR TITLE
php-7.2 fix - 'each' has been deprecated

### DIFF
--- a/classes/database/ADODB_base.php
+++ b/classes/database/ADODB_base.php
@@ -58,10 +58,7 @@ class ADODB_base {
 	 * @return The cleaned array
 	 */
 	function arrayClean(&$arr) {
-		reset($arr);
-		while(list($k, $v) = each($arr))
-			$arr[$k] = addslashes($v);
-		return $arr;
+		return $arr = array_map('addslashes', $arr);
 	}
 	
 	/**
@@ -132,8 +129,6 @@ class ADODB_base {
 	function delete($table, $conditions, $schema = '') {
 		$this->fieldClean($table);
 
-		reset($conditions);
-
 		if (!empty($schema)) {
 			$this->fieldClean($schema);
 			$schema = "\"{$schema}\".";
@@ -141,7 +136,7 @@ class ADODB_base {
 
 		// Build clause
 		$sql = '';
-		while(list($key, $value) = each($conditions)) {
+		foreach($conditions as $key => $value) {
 			$this->clean($key);
 			$this->clean($value);
 			if ($sql) $sql .= " AND \"{$key}\"='{$value}'";
@@ -220,23 +215,20 @@ class ADODB_base {
 		$whereClause = '';
 
 		// Populate the syntax arrays
-		reset($vars);
-		while(list($key, $value) = each($vars)) {
+		foreach($vars as $key => $value) {
 			$this->fieldClean($key);
 			$this->clean($value);
 			if ($setClause) $setClause .= ", \"{$key}\"='{$value}'";
 			else $setClause = "UPDATE \"{$table}\" SET \"{$key}\"='{$value}'";
 		}
 
-		reset($nulls);
-		while(list(, $value) = each($nulls)) {
+		foreach($nulls as $value) {
 			$this->fieldClean($value);
 			if ($setClause) $setClause .= ", \"{$value}\"=NULL";
 			else $setClause = "UPDATE \"{$table}\" SET \"{$value}\"=NULL";
 		}
 
-		reset($where);
-		while(list($key, $value) = each($where)) {
+		foreach($where as $key => $value) {
 			$this->fieldClean($key);
 			$this->clean($value);
 			if ($whereClause) $whereClause .= " AND \"{$key}\"='{$value}'";

--- a/dataexport.php
+++ b/dataexport.php
@@ -124,7 +124,7 @@
 				echo " FROM stdin;\n";
 				while (!$rs->EOF) {
 					$first = true;
-					while(list($k, $v) = each($rs->fields)) {
+					foreach ($rs->fields as $k => $v) {
 						// Escape value
 						$v = $data->escapeBytea($v);
 						

--- a/libraries/adodb/adodb-datadict.inc.php
+++ b/libraries/adodb/adodb-datadict.inc.php
@@ -518,7 +518,7 @@ class ADODB_DataDict {
 			list($lines,$pkey,$idxs) = $this->_GenFields($flds);
 			// genfields can return FALSE at times
 			if ($lines == null) $lines = array();
-			list(,$first) = each($lines);
+			$first = reset($lines);
 			list(,$column_def) = preg_split("/[\t ]+/",$first,2);
 		}
 		return array(sprintf($this->renameColumn,$tabname,$this->NameQuote($oldcolumn),$this->NameQuote($newcolumn),$column_def));

--- a/libraries/adodb/adodb-error.inc.php
+++ b/libraries/adodb/adodb-error.inc.php
@@ -102,8 +102,7 @@ function adodb_error_pg($errormsg)
 			'/Relation [\"\'].*[\"\'] already exists|Cannot insert a duplicate key into (a )?unique index.*|duplicate key.*violates unique constraint/i'     
 			 	 => DB_ERROR_ALREADY_EXISTS
         );
-	reset($error_regexps);
-    while (list($regexp,$code) = each($error_regexps)) {
+	foreach($error_regexps as $regexp => $code) {
         if (preg_match($regexp, $errormsg)) {
             return $code;
         }

--- a/libraries/adodb/adodb.inc.php
+++ b/libraries/adodb/adodb.inc.php
@@ -963,8 +963,7 @@
 				if (!$array_2d) $inputarr = array($inputarr);
 				foreach($inputarr as $arr) {
 					$sql = ''; $i = 0;
-					//Use each() instead of foreach to reduce memory usage -mikefedyk
-					while(list(, $v) = each($arr)) {
+					foreach($arr as $v) {
 						$sql .= $sqlarr[$i];
 						// from Ron Baldwin <ron.baldwin#sourceprose.com>
 						// Only quote string types	

--- a/libraries/adodb/toexport.inc.php
+++ b/libraries/adodb/toexport.inc.php
@@ -72,10 +72,8 @@ function _adodb_export(&$rs,$sep,$sepreplace,$fp=false,$addtitles=true,$quote = 
 	
 	if ($addtitles) {
 		$fieldTypes = $rs->FieldTypesArray();
-		reset($fieldTypes);
 		$i = 0;
-		while(list(,$o) = each($fieldTypes)) {
-		
+		foreach($fieldTypes as $o) {
 			$v = ($o) ? $o->name : 'Field'.($i++);
 			if ($escquote) $v = str_replace($quote,$escquotequote,$v);
 			$v = strip_tags(str_replace("\n", $replaceNewLine, str_replace("\r\n",$replaceNewLine,str_replace($sep,$sepreplace,$v))));


### PR DESCRIPTION
this prevents PHP 7.2 from throwing 

> PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in phppgadmin/libraries/adodb/adodb-error.inc.php on line 106

see also the deprecation notice on https://php.net/each