### PR TITLE
Support truncation of multibyte strings

### DIFF
--- a/lang/english.php
+++ b/lang/english.php
@@ -177,7 +177,8 @@
 	$lang['strnoframes'] = 'This application works best with a frames-enabled browser, but can be used without frames by following the link below.';
 	$lang['strnoframeslink'] = 'Use without frames';
 	$lang['strbadconfig'] = 'Your config.inc.php is out of date. You will need to regenerate it from the new config.inc.php-dist.';
-	$lang['strnotloaded'] = 'Your PHP installation does not support PostgreSQL. You need to recompile PHP using the --with-pgsql configure option.';
+	$lang['strlibnotfound'] = 'Your PHP installation does not support the %s module. You will need to install, enable, or compile it to use phpPgAdmin.';
+	$lang['strlibnotfound_plural'] = 'Your PHP installation does not support the %s modules. You will need to install, enable, or compile them to use phpPgAdmin.';
 	$lang['strpostgresqlversionnotsupported'] = 'Version of PostgreSQL not supported. Please upgrade to version %s or later.';
 	$lang['strbadschema'] = 'Invalid schema specified.';
 	$lang['strbadencoding'] = 'Failed to set client encoding in database.';

--- a/libraries/lib.inc.php
+++ b/libraries/lib.inc.php
@@ -208,9 +208,19 @@
 		exit;
 	}
 
-	// Check database support is properly compiled in
-	if (!function_exists('pg_connect')) {
-		echo $lang['strnotloaded'];
+	// Check php libraries
+	$php_libraries_requirements = [
+		// required_function => name_of_the_php_library
+		'pg_connect' => 'pgsql',
+		'mb_strlen' => 'mbstring'];
+	$missing_libraries = [];
+	foreach($php_libraries_requirements as $funcname => $lib)
+		if (!function_exists($funcname))
+			$missing_libraries[] = $lib;
+	if ($missing_libraries) {
+		$missing_list = implode(', ', $missing_libraries);
+		$error_missing_template_string = count($missing_libraries) <= 1 ? $lang['strlibnotfound'] : $lang['strlibnotfound_plural'];
+		printf($error_missing_template_string, $missing_list);
 		exit;
 	}
 


### PR DESCRIPTION
This fixes https://sourceforge.net/p/phppgadmin/bugs/422/ :
substr truncates on a byte-level, sometimes within a multi-byte character. This resulted in the whole string sometime not being displayed. See the original bug report for a way to reproduce.

Please note that this requires php-mbstring to be installed. This is usually the case, but the dependency should be described in the INSTALL file or something.