### PR TITLE
xtree: tables & views can't expand the browse item

### DIFF
--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -1023,7 +1023,6 @@
 							'url'   => 'display.php',
 							'urlvars' => array ('subject' => 'table','table' => field('table')),
 							'return' => 'table',
-							'branch'=> true,
 						),
 						'select' => array(
 							'title' => $lang['strselect'],
@@ -1129,7 +1128,6 @@
 									'subject' => 'view',
 									'view' => field('view')
 							),
-							'branch'=> true,
 						),
 						'select' => array(
 							'title' => $lang['strselect'],


### PR DESCRIPTION
In the left tree, in tables and views, when one click on the + of browse, a message like "Erreur lors du chargement display.php?action=tree&return=schema&subject=view&view=test+vue&server=localhost%3A5432%3Aallow&database=bug422&schema=public (200: OK)" is displayed.

These items don't support tree actions, and the tree expansion should be be offered in the first place.