### PR TITLE
Drop PHP safe mode howto

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,26 +24,7 @@ phpPgAdmin Installation Guide
    If you mess up the configuration file, you can recover it from the
    config.inc.php-dist file.
 
-3. If you run your PHP installation in safe mode, in order that the database
-   dump feature can work correctly, you need to set the 'safe_mode_allowed_env_vars'
-   php.ini variable to include the PGPASSWORD and PGUSER environmental variables
-   and the safe_mode_exec_dir to include /usr/bin (or wherever the pg_dump
-   binaries are found).
-   
-   	eg. safe_mode_allowed_env_vars = PHP_,PG
-   	    safe_mode_exec_dir = /usr/bin
-   
-   Given that you usually don't want to allow everything in /usr/bin to
-   be executed, you might want to copy the pg_dump and pg_dumpall utilities
-   to a directory by themselves.
-   
-   Also, you will need to ensure that your 'pg_dump' and 'pg_dumpall' utilities
-   are executable by the PHP process, if you want dump support in phpPgAdmin.
-
-   Lastly, if you run phpPgAdmin in safe mode, very long running imports,
-   exports and transactions may time out and be aborted.
-
-4. Ensure the statistics collector is enabled in PostgreSQL.  phpPgAdmin will 
+3. Ensure the statistics collector is enabled in PostgreSQL.  phpPgAdmin will 
    display table, index performance, and usage statistics if you have enabled
    the PostgreSQL statistics collector.  While this is normally enabled by 
    default, to ensure it is running, make sure the following lines in your 
@@ -52,10 +33,10 @@ phpPgAdmin Installation Guide
     track_activities
     track_counts 
 
-5. Browse to the phpPgAdmin installation using a web browser.  You might
+4. Browse to the phpPgAdmin installation using a web browser.  You might
    need cookies enabled for phpPgAdmin to work.
 
-6. IMPORTANT - SECURITY
+5. IMPORTANT - SECURITY
 
    PostgreSQL by default does not require you to use a password to log in.
    We STRONGLY recommend that you enable md5 passwords for local connections


### PR DESCRIPTION
Safe mode disappeared with php 5.4 (September 2015), and version 7.1 or above is required.
https://www.php.net/manual/en/features.safe-mode.php