### PR TITLE
Drop obsolete export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 /tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.build_tests.php export-ignore


### PR DESCRIPTION
.build_tests.php no longer exists: There is no need to exclude it.