### PR TITLE
Fix links to docs for pgsql 13 & 14

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -419,7 +419,7 @@ class Postgres extends ADODB_base {
 	}
 
 	function getHelpPages() {
-		include_once('./help/PostgresDoc95.php');
+		include_once('./help/PostgresDoc14.php');
 		return $this->help_page;
 	}
 

--- a/help/PostgresDoc13.php
+++ b/help/PostgresDoc13.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Help links for PostgreSQL 9.5 documentation
+ *
+ * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
+ */
+
+include('./help/PostgresDoc12.php');
+
+$this->help_base = sprintf($GLOBALS['conf']['help_base'], '13');
+
+?>

--- a/help/PostgresDoc14.php
+++ b/help/PostgresDoc14.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Help links for PostgreSQL 9.5 documentation
+ *
+ * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
+ */
+
+include('./help/PostgresDoc13.php');
+
+$this->help_base = sprintf($GLOBALS['conf']['help_base'], 'devel');
+
+?>


### PR DESCRIPTION
For version 14, we point to the /devel/ docs, since that version is currently
in dev. I also bumped the fall through to point to v14, arguably we could
instead point to /current/, but any current version will work, so I think
devel is more likely.