### PR TITLE
Remove php5 from tests

### DIFF
--- a/tests/simpletests/tests.php
+++ b/tests/simpletests/tests.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php5
+#!/usr/bin/php
 <?php
 require_once('../conf/config.inc.php');
 require_once('../lang/recoded/english.php');


### PR DESCRIPTION
Hi!

In the tests php5 still existing. It's fail building RPM file:

```
conflicting requests
 - nothing provides /usr/bin/php5 
```