### PR TITLE
Consider group membership when testing owned_only

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -450,7 +450,7 @@ class Postgres extends ADODB_base {
 		if (isset($conf['owned_only']) && $conf['owned_only'] && !$this->isSuperUser()) {
 			$username = $server_info['username'];
 			$this->clean($username);
-			$clause = " AND pr.rolname='{$username}'";
+			$clause = " AND pg_has_role('{$username}'::name,pr.rolname,'USAGE')";
 		}
 		else $clause = '';
 


### PR DESCRIPTION
Based on code and suggestions from @cathysax, ultimately I used the internal
pg_has_role function to test whether a user has ownership rights based on
group membership. I actually check for 'USAGE' rights, since that implies the
role has rights without the need to `set role`, which users wouldn't be able to do
with a normal PPA login. Loosely tested back to 9.5.

This fixes https://github.com/phppgadmin/phppgadmin/issues/102