### PR TITLE
Fix national-encoding in CREDITS

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -21,15 +21,15 @@ Translators
 - Tadashi Jokagi (Japanese)
 - Rafal Slubowski (Polish)
 - Alexander Khodorisky (Russian)
-- Martin Marqués (Spanish)
+- Martin MarquÃ©s (Spanish)
 - Andrej Misovic (Slovak)
 - Devrim Gunduz (Turkish)
 - Libor Vanek (Czech)
-- Marek Cernocký (Czech)
+- Marek ÄŒernockÃ½ (Czech)
 - Stefan Malmqvist (Swedish)
 - Nicola Soranzo (Italian)
 - Petri Jooste (Afrikaans)
-- Sulyok Péter (Hungarian)
+- Sulyok PÃ©ter (Hungarian)
 - Zaki Almuallim (Arabic)
 - Erdenemandal Bat-Erdene (Mongolian)
 - Alex Rootoff (Ukrainian)
@@ -40,9 +40,8 @@ Translators
 - Bernat Pegueroles (Catalan)
 - Fernando Wendt (Brazilan Portuguese)
 - Adamantios Diamantidis (Greek)
-- Marek ¿ernocký (Czech)
 - Alexey Baturin (Russian UTF8)
-- Adrián Chaves Fernández (Galician)
+- AdriÃ¡n Chaves FernÃ¡ndez (Galician)
 
 Look & Feel
 
@@ -79,7 +78,7 @@ Contributors
 - Leonardo Augusto Sapiras (Improve phpPgAdmin ergonomy during the GSoC 2010, with ioguix as mentor)
 - Julien Rouhaud, aka. rjuju (nested groups)
 - Felipe Figueroa aka. amenadiel
-- Jean-Michel Vourgère (nirgal)
+- Jean-Michel VourgÃ¨re (nirgal)
 
 Third Party Libraries
 


### PR DESCRIPTION
There was a non-UTF8 character in Marek Černocký last name. Moreover, he was already listed.