### PR TITLE
Default connect via TCP rather that socket

### DIFF
--- a/conf/config.inc.php-dist
+++ b/conf/config.inc.php-dist
@@ -15,7 +15,7 @@
 
 	// Hostname or IP address for server.  Use '' for UNIX domain socket.
 	// use 'localhost' for TCP/IP connection on this computer
-	$conf['servers'][0]['host'] = '';
+	$conf['servers'][0]['host'] = 'localhost';
 
 	// Database port on server (5432 is the PostgreSQL default)
 	$conf['servers'][0]['port'] = 5432;


### PR DESCRIPTION
Go through localhost instead of Unix-domain socket because localhost allows
password access by default on Debian; Unix-domain socket uses ident, which
doesn't work through the web server.