### PR TITLE
Restore support for PostgreSQL 9.4 and below

### DIFF
--- a/classes/database/Postgres94.php
+++ b/classes/database/Postgres94.php
@@ -5,9 +5,9 @@
  *
  */
 
-include_once('./classes/database/Postgres.php');
+include_once('./classes/database/Postgres95.php');
 
-class Postgres94 extends Postgres {
+class Postgres94 extends Postgres95 {
 
 	var $major_version = 9.4;
 


### PR DESCRIPTION
The changes made in #53 neglected to change `classes/database/Postgres94.php` so that it would inherit from the new `classes/database/Postgres95.php`. At the very least, this is the cause of #68.