### PR TITLE
Handy preview of clipped content (without full view expansion - and some minor tweaks)

### DIFF
--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -261,8 +261,12 @@
 			if (isset($params['clip']) && $params['clip'] === true) {
 				$maxlen = isset($params['cliplen']) && is_integer($params['cliplen']) ? $params['cliplen'] : $conf['max_chars'];
 				$ellipsis = isset($params['ellipsis']) ? $params['ellipsis'] : $lang['strellipsis'];
-				if (mb_strlen($str, 'UTF-8') > $maxlen) {
+				if (mb_strlen($str, 'UTF-8') > $maxlen + mb_strlen($ellipsis)) {
+					$full_str = $ellipsis . mb_substr($str, $maxlen-1, $maxlen*8, 'UTF-8');
 					$str = mb_substr($str, 0, $maxlen-1, 'UTF-8') . $ellipsis;
+				} elseif (strlen($str) > 19 and substr($type, 0, 9) == 'timestamp') {
+					$full_str = substr($str, 19, $maxlen*8);
+					$str = substr($str, 0, 19);
 				}
 			}
 
@@ -307,6 +311,10 @@
 					$tag = 'div';
 					$class = 'pre';
 					$out = $data->escapeBytea($str);
+					break;
+				case 'macaddr':
+					$tag = 'tt';
+					$out = $str;
 					break;
 				case 'errormsg':
 					$tag = 'pre';
@@ -373,8 +381,10 @@
 						$tag = 'pre';
 						$class = 'data';
 						$out = htmlspecialchars($str);
+						if (isset($full_str)) $out = '<abbr title="' . htmlspecialchars($full_str) . "\">$out</abbr>";
 					} else {
 						$out = nl2br(htmlspecialchars($str));
+						if (isset($full_str)) $out = '<abbr title="' . nl2br(htmlspecialchars($full_str)) . "\">$out</abbr>";
 					}
 			}
 

--- a/themes/gotar/global.css
+++ b/themes/gotar/global.css
@@ -88,6 +88,10 @@ tr.data1, tr.data2, tr.data3 {
 tr.data1:hover, tr.data2:hover, tr.data3:hover {
 	background-color: #39663e;
 }
+abbr[title] {
+	text-decoration: none;
+	opacity: 0.80;
+}
 .row1, .data1 {
 	background-color: #2b482e;
 	text-align: left;


### PR DESCRIPTION
- do not truncate output at cliplen when it's exceeded only by $ellipsis length,
- put more of the clipped output into <abbr> for fast content preview,
- clip subsecond part of timestamp* types,
- display macaddr as <tt>