### PR TITLE
Use TABLE's primary key for (second order) sorting, maily to keep it consistent between pages

### DIFF
--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -7801,15 +7801,15 @@ class Postgres extends ADODB_base {
 	 * @return -4 unknown type
 	 * @return -5 failed setting transaction read only
 	 */
-	function browseQuery($type, $table, $query, $sortkey, $sortdir, $page, $page_size, &$max_pages) {
+	function browseQuery($type, $table, $query, $sortkey, $sortdir, $page, $page_size, &$max_pages, $sort_pkey = null) {
 		// Check that we're not going to divide by zero
 		if (!is_numeric($page_size) || $page_size != (int)$page_size || $page_size <= 0) return -3;
 
 		// If $type is TABLE, then generate the query
 		switch ($type) {
 			case 'TABLE':
-				if (preg_match('/^[0-9]+$/', $sortkey) && $sortkey > 0) $orderby = array($sortkey => $sortdir);
-				else $orderby = array();
+				if (preg_match('/^[0-9]+$/', $sortkey) && $sortkey > 0) $orderby = array($sortkey => $sortdir, $sort_pkey ?: '1' => $sortdir);
+				else $orderby = array($sort_pkey ?: '1' => 'DESC');
 				$query = $this->getSelectSQL($table, array(), array(), array(), $orderby);
 				break;
 			case 'QUERY':

--- a/display.php
+++ b/display.php
@@ -283,6 +283,7 @@
 
 						$fkey_information['byfield'][$constr['p_field']][] = $constr['conid'];
 					}
+					elseif ($constr['contype'] == 'p') $fkey_information['pkey'] = $constr['p_field'];
 					$constraints->moveNext();
 				}
 			}
@@ -494,14 +495,15 @@
 			}
 		}
 
+		$fkey_information =& getFKInfo();
+
 		// Retrieve page from query.  $max_pages is returned by reference.
 		$rs = $data->browseQuery($type, 
 			isset($object) ? $object : null, 
 			isset($_SESSION['sqlquery']) ? $_SESSION['sqlquery'] : null,
 			$_REQUEST['sortkey'], $_REQUEST['sortdir'], $_REQUEST['page'],
-			$conf['max_rows'], $max_pages);
-
-		$fkey_information =& getFKInfo();
+			$conf['max_rows'], $max_pages,
+			isset($fkey_information['pkey']) ? $fkey_information['pkey'] : null);
 
 		// Build strings for GETs in array
 		$_gets = array(


### PR DESCRIPTION
This can't be easily (and properly!) done for QUERY nor SELECT unfortunately.