### PR TITLE
Recognize new objects: materialized views [MV], foreign tables [FDW] …

### DIFF
--- a/indexes.php
+++ b/indexes.php
@@ -247,8 +247,12 @@
 				$rowdata->fields['+constraints'] = $lang['strprimarykey'];
 				$actions['drop']['disable'] = true;
 			}
-			elseif ($data->phpBool($rowdata->fields['indisunique'])) {
+			elseif ($data->phpBool($rowdata->fields['indisunique']) and !$data->phpBool($rowdata->fields['indpred'])) {
 				$rowdata->fields['+constraints'] = $lang['struniquekey'];
+				$actions['drop']['disable'] = true;
+			}
+			elseif ($data->phpBool($rowdata->fields['indisexclusion'])) {
+				$rowdata->fields['+constraints'] = 'Exclusion';
 				$actions['drop']['disable'] = true;
 			}
 			else


### PR DESCRIPTION
…and exclusion constraints.

Additionally, allow to remove partial UNIQUE index from indexes tab as it's not a TABLE CONSTRAINT.
This is not even a preliminary handling of these object types (only COMMENT ON FOREIGN TABLE is
actually added), but at least we can see and browse them.