### PR TITLE
Remove duplicate erroneous translation strings

### DIFF
--- a/lang/danish.php
+++ b/lang/danish.php
@@ -609,7 +609,6 @@
 	$lang['strtablespacealteredbad'] = 'Ændring af tabelområde lykkedes ikke.';
 	
 	// Miscellaneous
-	$lang['strtopbar'] = '%s Kører på %s:%s -- Du er logged ind som bruger "%s", %s';
 	$lang['strtimefmt'] = 'jS M, Y g:iA';
 	$lang['strhelp'] = 'Hjælp';
 	$lang['strhelpicon'] = '?';

--- a/lang/danish.php
+++ b/lang/danish.php
@@ -609,7 +609,6 @@
 	$lang['strtablespacealteredbad'] = 'Ændring af tabelområde lykkedes ikke.';
 	
 	// Miscellaneous
-	$lang['strtimefmt'] = 'jS M, Y g:iA';
 	$lang['strhelp'] = 'Hjælp';
 	$lang['strhelpicon'] = '?';
 

--- a/lang/swedish.php
+++ b/lang/swedish.php
@@ -558,7 +558,6 @@
 	$lang['strrows2'] = 'Rader';
 
 	// Miscellaneous
-	$lang['strtopbar'] = '%s Körs på %s:%s -- Du är inloggad som användare "%s", %s';
 	$lang['strtimefmt'] = 'jS M, Y g:iA';
 	$lang['strhelp'] = 'Hjälp';
 

--- a/lang/swedish.php
+++ b/lang/swedish.php
@@ -558,7 +558,6 @@
 	$lang['strrows2'] = 'Rader';
 
 	// Miscellaneous
-	$lang['strtimefmt'] = 'jS M, Y g:iA';
 	$lang['strhelp'] = 'Hjälp';
 
 ?>


### PR DESCRIPTION
Fixes "PHP Warning:  sprintf(): Too few arguments in /usr/share/phpPgAdmin/classes/Misc.php on line 1346" in version "phpPgAdmin 5.6"

The same problem was present in both swedish & danish translations
Seems to have been a longstanding problem according to https://sourceforge.net/p/phppgadmin/bugs/430/
