### PR TITLE
PHP 8 support

### DIFF
--- a/all_db.php
+++ b/all_db.php
@@ -105,7 +105,7 @@
 
 			} else {
 		            echo "<p>", sprintf($lang['strconfdropdatabase'], $misc->printVal($_REQUEST['dropdatabase'])), "</p>\n";
-			        echo "<input type=\"hidden\" name=\"dropdatabase\" value=\"", htmlspecialchars($_REQUEST['dropdatabase']), "\" />\n";
+				        echo "<input type=\"hidden\" name=\"dropdatabase\" value=\"", htmlspecialchars($_REQUEST['dropdatabase']), "\" />\n";
             }// END if multi drop
 
 			echo "<input type=\"hidden\" name=\"action\" value=\"drop\" />\n";
@@ -199,7 +199,7 @@
 		echo "\t\t<td class=\"data1\">\n";
 		echo "\t\t\t<select name=\"formEncoding\">\n";
 		echo "\t\t\t\t<option value=\"\"></option>\n";
-		while (list ($key) = each ($data->codemap)) {
+		foreach ($data->codemap as $key => $value) {
 		    echo "\t\t\t\t<option value=\"", htmlspecialchars($key), "\"",
 				($key == $_POST['formEncoding']) ? ' selected="selected"' : '', ">",
 				$misc->printVal($key), "</option>\n";

--- a/libraries/adodb/drivers/adodb-postgres64.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres64.inc.php
@@ -121,6 +121,11 @@ WHERE relkind in ('r','v') AND (c.relname='%s' or c.relname = lower('%s'))
 	{
 	// changes the metaColumnsSQL, adds columns: attnum[6]
 	}
+
+	function __construct()
+	{
+	// changes the metaColumnsSQL, adds columns: attnum[6]
+	}
 	
 	function ServerInfo()
 	{
@@ -803,7 +808,7 @@ WHERE (c2.relname=\'%s\' or c2.relname=lower(\'%s\'))';
 		else return 'Database connection failed';
 	}
 
-	/*	Returns: the last error message from previous database operation	*/	
+	/*	Returns: the last error message from previous database operatio*/	
 	function ErrorMsg() 
 	{
 		if ($this->_errorMsg !== false) return $this->_errorMsg;


### PR DESCRIPTION
These changes allow phpPgAdmin to work with PHP 8, rather than the now obsolete and out of support PHP 7. I am not sure how the spacing got changed on the line reading:
echo "<input type=\"hidden\" name=\"dropdatabase\" value=\"",
but that change (obviously) is not needed.