### PR TITLE
Support Postgres 15 and beyond

### DIFF
--- a/classes/database/Connection.php
+++ b/classes/database/Connection.php
@@ -81,6 +81,7 @@ class Connection {
             case '12': return 'Postgres12';break;
             case '11': return 'Postgres11';break;
             case '10': return 'Postgres10';break;
+	    default: return 'Postgres';break; 
         }    
 
 		switch (substr($version,0,3)) {


### PR DESCRIPTION
Doesn't seem to work with Postgres 15, a default to the case statement seems to resolve this and may address future major incompatibilities. 